### PR TITLE
fix: off-by-one error in post fetching

### DIFF
--- a/archive.py
+++ b/archive.py
@@ -223,7 +223,7 @@ def main() -> None:
 
         time.sleep(5)
         posts = http_get_json(
-            f'/posts.json?before={last_id - 1}')['latest_posts']
+            f'/posts.json?before={last_id}')['latest_posts']
 
         # Discourse implicitly limits the posts query for IDs between `before` and
         # `before - 50`, so if we don't get any results we have to kind of scan.


### PR DESCRIPTION
This caused posts to be missing from my archives.

`last_id` is the last ID we fetched a post for. The ?before=id argument is exclusive (https://docs.discourse.org/#tag/Posts/operation/listPosts) so it will return posts with a `id - 1`. By decrementing, we were actually fetching posts with `id - 2`, so we were skipping the post with `id - 1`.

Noticed this while building a mirroring tool that creates HTML pages for topics from the JSON files.

This may be related to https://github.com/jamesob/delving-bitcoin-archive/pull/1 which mentions that some posts are missing. I didn't check.